### PR TITLE
Added PhoneBridge to extract existing account from an android phone

### DIFF
--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -14,7 +14,7 @@ namespace SteamAuth
         private Process console;
         private ManualResetEvent mreOutput = new ManualResetEvent(false);
 
-        public delegate EventHandler BridgeError(string msg);
+        public delegate void BridgeError(string msg);
         public event BridgeError PhoneBridgeError;
         private void OnPhoneBridgeError(string msg)
         {

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -11,6 +11,8 @@ namespace SteamAuth
 {
     public class PhoneBridge
     {
+        public bool OutputToConsole = true;
+
         private Process console;
         private ManualResetEvent mreOutput = new ManualResetEvent(false);
 
@@ -39,7 +41,7 @@ namespace SteamAuth
 
             console.OutputDataReceived += (sender, e) =>
             {
-                if (e.Data.Contains(">@")) return;
+                if (e.Data.Contains(">@") || !OutputToConsole) return;
                 Console.WriteLine(e.Data);
             };
         }

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -55,14 +55,15 @@ namespace SteamAuth
             if (!DeviceUp()) errored = "Device not detected";
             if (!IsRooted()) errored = "Device not rooted";
             if (!SteamAppInstalled()) errored = "Steam Community App not installed";
-            if (errored != null)
+            if (errored != "")
             {
                 OnPhoneBridgeError(errored);
                 return null;
             }
 
             // Pull the JSON from the device
-            var sgj = JsonConvert.DeserializeObject<SteamGuardAccount>(PullJson());
+            var json = PullJson();
+            var sgj = JsonConvert.DeserializeObject<SteamGuardAccount>(json);
 
             return sgj;
         }

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -75,6 +75,11 @@ namespace SteamAuth
             {
                 if (e.Data.Contains(">@") || e.Data == "") return;
                 if (!e.Data.StartsWith("{")) return;
+                if (e.Data.Contains("No such file or directory"))
+                {
+                    mre.Set();
+                    return;
+                }
                 json = e.Data;
                 mre.Set();
             };

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -31,7 +31,7 @@ namespace SteamAuth
             console.StartInfo.UseShellExecute = false;
             console.StartInfo.RedirectStandardOutput = true;
             console.StartInfo.RedirectStandardInput = true;
-            console.StartInfo.CreateNoWindow = false;
+            console.StartInfo.CreateNoWindow = true;
             console.StartInfo.FileName = "CMD.exe";
             console.StartInfo.Arguments = "/K";
             console.Start();

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -1,0 +1,181 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SteamAuth
+{
+    class PhoneBridge
+    {
+        private Process console;
+        private ManualResetEvent mreOutput = new ManualResetEvent(false);
+
+        public delegate EventHandler BridgeError(string msg);
+        public event BridgeError PhoneBridgeError;
+        private void OnPhoneBridgeError(string msg)
+        {
+            if (PhoneBridgeError != null)
+                PhoneBridgeError(msg);
+        }
+
+        private void InitConsole()
+        {
+            if (console != null) return;
+
+            console = new Process();
+
+            console.StartInfo.UseShellExecute = false;
+            console.StartInfo.RedirectStandardOutput = true;
+            console.StartInfo.RedirectStandardInput = true;
+            console.StartInfo.CreateNoWindow = false;
+            console.StartInfo.FileName = "CMD.exe";
+            console.StartInfo.Arguments = "/K";
+            console.Start();
+            console.BeginOutputReadLine();
+
+            console.OutputDataReceived += (sender, e) =>
+            {
+                if (e.Data.Contains(">@")) return;
+                Console.WriteLine(e.Data);
+            };
+        }
+
+        public SteamGuardAccount ExtractSteamGuardAccount()
+        {
+            string errored = "";
+
+            InitConsole(); // Init the console
+
+            // Check required states
+            if (!CheckAdb()) errored = "ADB not found";
+            if (!DeviceUp()) errored = "Device not detected";
+            if (!IsRooted()) errored = "Device not rooted";
+            if (!SteamAppInstalled()) errored = "Steam Community App not installed";
+            if (errored != null)
+            {
+                OnPhoneBridgeError(errored);
+                return null;
+            }
+
+            // Pull the JSON from the device
+            var sgj = JsonConvert.DeserializeObject<SteamGuardAccount>(PullJson());
+
+            return sgj;
+        }
+
+        private string PullJson()
+        {
+            string json = null;
+            ManualResetEventSlim mre = new ManualResetEventSlim();
+            DataReceivedEventHandler f1 = (sender, e) =>
+            {
+                if (e.Data.Contains(">@") || e.Data == "") return;
+                if (!e.Data.StartsWith("{")) return;
+                json = e.Data;
+                mre.Set();
+            };
+
+            console.OutputDataReceived += f1;
+
+            ExecuteCommand("adb shell su -c \"cat /data/data/com.valvesoftware.android.steam.community/files/Steamguard-*\"");
+            mre.Wait();
+
+            console.OutputDataReceived -= f1;
+
+            return json;
+        }
+        private bool CheckAdb()
+        {
+            bool exists = true;
+            Process p = new Process();
+
+            p.StartInfo.FileName = "adb.exe";
+            p.StartInfo.CreateNoWindow = true;
+            p.StartInfo.UseShellExecute = false;
+
+            try
+            {
+                p.Start();
+            }
+            catch (Exception)
+            {
+                exists = false;
+            }
+
+            return exists;
+        }
+        private bool DeviceUp()
+        {
+            bool up = false;
+            ManualResetEventSlim mre = new ManualResetEventSlim();
+            DataReceivedEventHandler f1 = (sender, e) =>
+            {
+                if (e.Data.Contains(">@")) return;
+                if (e.Data.Contains("device"))
+                    up = true;
+                mre.Set();
+            };
+
+            console.OutputDataReceived += f1;
+
+            ExecuteCommand("adb get-state");
+            mre.Wait();
+
+            console.OutputDataReceived -= f1;
+
+            return up;
+        }
+        private bool SteamAppInstalled()
+        {
+            bool ins = false;
+            ManualResetEventSlim mre = new ManualResetEventSlim();
+            DataReceivedEventHandler f1 = (sender, e) =>
+            {
+                if (e.Data.Contains(">@") || e.Data == "") return;
+                if (e.Data == "Yes")
+                    ins = true;
+                mre.Set();
+            };
+
+            console.OutputDataReceived += f1;
+
+            ExecuteCommand("adb shell \"cd /data/data/com.valvesoftware.android.steam.community && echo Yes\"");
+            mre.Wait();
+
+            console.OutputDataReceived -= f1;
+
+            return ins;
+        }
+        private bool IsRooted()
+        {
+            bool root = false;
+            ManualResetEventSlim mre = new ManualResetEventSlim();
+            DataReceivedEventHandler f1 = (sender, e) =>
+            {
+                if (e.Data.Contains(">@") || e.Data == "") return;
+                if (e.Data == "Yes")
+                    root = true;
+                mre.Set();
+            };
+
+            console.OutputDataReceived += f1;
+
+            ExecuteCommand("adb shell su -c echo Yes");
+            mre.Wait();
+
+            console.OutputDataReceived -= f1;
+
+            return root;
+        }
+
+        private void ExecuteCommand(string cmd)
+        {
+            console.StandardInput.WriteLine("@" + cmd);
+            console.StandardInput.Flush();
+        }
+    }
+}

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -42,7 +42,8 @@ namespace SteamAuth
             console.OutputDataReceived += (sender, e) =>
             {
                 if (e.Data.Contains(">@") || !OutputToConsole || e.Data == "") return;
-                Console.WriteLine(e.Data);
+                if (OutputToConsole)
+                    Console.WriteLine(e.Data);
             };
         }
 

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -24,6 +24,8 @@ namespace SteamAuth
                 PhoneBridgeError(msg);
         }
 
+        private string Error = "";
+
         private void InitConsole()
         {
             if (console != null) return;
@@ -49,17 +51,13 @@ namespace SteamAuth
 
         public SteamGuardAccount ExtractSteamGuardAccount()
         {
-            string errored = "";
-
             InitConsole(); // Init the console
 
             // Check required states
-            if (!CheckAdb()) errored = "ADB not found";
-            if (!DeviceUp()) errored = "Device not detected";
-            if (!SteamAppInstalled()) errored = "Steam Community App not installed";
-            if (errored != null && errored != "")
+            Error = ErrorsFound();
+            if (Error != "")
             {
-                OnPhoneBridgeError(errored);
+                OnPhoneBridgeError(Error);
                 return null;
             }
 
@@ -72,6 +70,14 @@ namespace SteamAuth
             }
 
             return acc;
+        }
+
+        private string ErrorsFound()
+        {
+            if (!CheckAdb()) return "ADB not found";
+            if (!DeviceUp()) return "Device not detected";
+            if (!SteamAppInstalled()) return "Steam Community app not installed";
+            return "";
         }
 
         private string PullJson()
@@ -145,6 +151,8 @@ namespace SteamAuth
             mre.Reset();
             ExecuteCommand("adb shell \"rm -dR /sdcard/steamauth\" & echo Done");
             mre.Wait();
+
+            System.IO.File.Delete("backup.ab");
 
             console.OutputDataReceived -= f1;
 

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -41,7 +41,7 @@ namespace SteamAuth
 
             console.OutputDataReceived += (sender, e) =>
             {
-                if (e.Data.Contains(">@") || !OutputToConsole) return;
+                if (e.Data.Contains(">@") || !OutputToConsole || e.Data == "") return;
                 Console.WriteLine(e.Data);
             };
         }

--- a/SteamAuth/PhoneBridge.cs
+++ b/SteamAuth/PhoneBridge.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace SteamAuth
 {
-    class PhoneBridge
+    public class PhoneBridge
     {
         private Process console;
         private ManualResetEvent mreOutput = new ManualResetEvent(false);

--- a/SteamAuth/SteamAuth.csproj
+++ b/SteamAuth/SteamAuth.csproj
@@ -47,6 +47,7 @@
     <Compile Include="APIEndpoints.cs" />
     <Compile Include="AuthenticatorLinker.cs" />
     <Compile Include="Confirmation.cs" />
+    <Compile Include="PhoneBridge.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SessionData.cs" />
     <Compile Include="SteamGuardAccount.cs" />


### PR DESCRIPTION
Added a class that will allow you to extract an existing Steam Guard account from a phone that has the Steam app installed and Steam Guard enabled.
When a PhoneBridge is instanciated and ExtractSteamGuardAccount is called, it will:
- Check if ADB exists in either in PATH variable or executable folder by running "ADB.exe"
- Check if any device is avaiable by running "adb get-state"
- Check if the device is rooted by executing "su"  on the device
- Check if the Steam app is installed
- Pull the JSON file called "Steamguard-X" (X being the user's SteamID64) in "/data/data/com.valvesoftware.android.steam.community/files/"
- If the device isn't rooted, an alternative method will be used (TODO: explain)
- Return the unserialized SteamGuardAccount object

It worked on my phone, but still, it may not work on all devices. If anyone can test it on their phones, please do so and post results.

Edit: Phone no longer needs to be rooted (please someone test this)