### PR TITLE
Misc fixes and improvements

### DIFF
--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -76,14 +76,17 @@ namespace SteamAuth
             if (response == null) return LinkResult.GeneralFailure;
 
             var addAuthenticatorResponse = JsonConvert.DeserializeObject<AddAuthenticatorResponse>(response);
-            if (addAuthenticatorResponse != null && addAuthenticatorResponse.Response != null)
+            if (addAuthenticatorResponse == null || addAuthenticatorResponse.Response == null)
             {
-                if (addAuthenticatorResponse.Response.Status == 29)
-                    return LinkResult.AuthenticatorPresent;
-                if (addAuthenticatorResponse.Response.Status != 1)
-                    return LinkResult.GeneralFailure;
+                return LinkResult.GeneralFailure;
             }
-            else
+
+            if (addAuthenticatorResponse.Response.Status == 29)
+            {
+                return LinkResult.AuthenticatorPresent;
+            }
+
+            if (addAuthenticatorResponse.Response.Status != 1)
             {
                 return LinkResult.GeneralFailure;
             }

--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -76,7 +76,14 @@ namespace SteamAuth
             if (response == null) return LinkResult.GeneralFailure;
 
             var addAuthenticatorResponse = JsonConvert.DeserializeObject<AddAuthenticatorResponse>(response);
-            if (addAuthenticatorResponse == null || addAuthenticatorResponse.Response == null || addAuthenticatorResponse.Response.Status != 1)
+            if (addAuthenticatorResponse != null && addAuthenticatorResponse.Response != null)
+            {
+                if (addAuthenticatorResponse.Response.Status == 29)
+                    return LinkResult.AuthenticatorPresent;
+                if (addAuthenticatorResponse.Response.Status != 1)
+                    return LinkResult.GeneralFailure;
+            }
+            else
             {
                 return LinkResult.GeneralFailure;
             }
@@ -181,7 +188,8 @@ namespace SteamAuth
             MustProvidePhoneNumber, //No phone number on the account
             MustRemovePhoneNumber, //A phone number is already on the account
             AwaitingFinalization, //Must provide an SMS code
-            GeneralFailure //General failure (really now!)
+            GeneralFailure, //General failure (really now!)
+            AuthenticatorPresent
         }
 
         public enum FinalizeResult

--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -43,7 +43,7 @@ namespace SteamAuth
         public AuthenticatorLinker(SessionData session)
         {
             this._session = session;
-            this.DeviceID = _generateDeviceID();
+            this.DeviceID = GenerateDeviceID();
 
             this._cookies = new CookieContainer();
             session.AddCookies(_cookies);
@@ -239,7 +239,7 @@ namespace SteamAuth
             public bool Success { get; set; }
         }
 
-        private string _generateDeviceID()
+        public static string GenerateDeviceID()
         {
             using (var sha1 = new SHA1Managed())
             {

--- a/SteamAuth/SteamGuardAccount.cs
+++ b/SteamAuth/SteamGuardAccount.cs
@@ -54,11 +54,11 @@ namespace SteamAuth
 
         private static byte[] steamGuardCodeTranslations = new byte[] { 50, 51, 52, 53, 54, 55, 56, 57, 66, 67, 68, 70, 71, 72, 74, 75, 77, 78, 80, 81, 82, 84, 86, 87, 88, 89 };
 
-        public bool DeactivateAuthenticator()
+        public bool DeactivateAuthenticator(int scheme = 2)
         {
             var postData = new NameValueCollection();
             postData.Add("steamid", this.Session.SteamID.ToString());
-            postData.Add("steamguard_scheme", "2");
+            postData.Add("steamguard_scheme", scheme.ToString());
             postData.Add("revocation_code", this.RevocationCode);
             postData.Add("access_token", this.Session.OAuthToken);
 

--- a/SteamAuth/SteamGuardAccount.cs
+++ b/SteamAuth/SteamGuardAccount.cs
@@ -241,6 +241,9 @@ namespace SteamAuth
 
         public string GenerateConfirmationQueryParams(string tag)
         {
+            if (String.IsNullOrEmpty(DeviceID))
+                DeviceID = AuthenticatorLinker.GenerateDeviceID();
+
             long time = TimeAligner.GetSteamTime();
             return "p=" + this.DeviceID + "&a=" + this.Session.SteamID.ToString() + "&k=" + _generateConfirmationHashForTime(time, tag) + "&t=" + time + "&m=android&tag=" + tag;
         }

--- a/SteamAuth/UserLogin.cs
+++ b/SteamAuth/UserLogin.cs
@@ -106,6 +106,11 @@ namespace SteamAuth
 
             var loginResponse = JsonConvert.DeserializeObject<LoginResponse>(response);
 
+            if (loginResponse.Message != null && loginResponse.Message.Contains("Incorrect login"))
+            {
+                return LoginResult.BadCredentials;
+            }
+
             if (loginResponse.CaptchaNeeded)
             {
                 this.RequiresCaptcha = true;

--- a/SteamAuth/UserLogin.cs
+++ b/SteamAuth/UserLogin.cs
@@ -59,7 +59,7 @@ namespace SteamAuth
 
             postData.Add("username", this.Username);
             response = SteamWeb.MobileLoginRequest(APIEndpoints.COMMUNITY_BASE + "/login/getrsakey", "POST", postData, cookies);
-            if (response == null) return LoginResult.GeneralFailure;
+            if (response == null || response.Contains("<BODY>\nAn error occurred while processing your request.")) return LoginResult.GeneralFailure;
 
             var rsaResponse = JsonConvert.DeserializeObject<RSAResponse>(response);
 
@@ -126,6 +126,11 @@ namespace SteamAuth
                 return LoginResult.Need2FA;
             }
 
+            if (loginResponse.Message != null && loginResponse.Message.Contains("too many login failures"))
+            {
+                return LoginResult.TooManyFailedLogins;
+            }
+
             if (loginResponse.OAuthData == null || loginResponse.OAuthData.OAuthToken == null || loginResponse.OAuthData.OAuthToken.Length == 0)
             {
                 return LoginResult.GeneralFailure;
@@ -189,6 +194,9 @@ namespace SteamAuth
             [JsonProperty("requires_twofactor")]
             public bool TwoFactorNeeded { get; set; }
 
+            [JsonProperty("message")]
+            public string Message { get; set; }
+
             internal class OAuth
             {
                 [JsonProperty("steamid")]
@@ -236,5 +244,6 @@ namespace SteamAuth
         NeedCaptcha,
         Need2FA,
         NeedEmail,
+        TooManyFailedLogins,
     }
 }


### PR DESCRIPTION
This pull request has 6 main improvements:

1. Fixed a rare crash where an error HTML page was returned instead of the RSA Json.
2. Added new `DoLogin` result type `TooManyFailedLogins`.
3. Added new `AddAuthenticator` result type `AuthenticatorPresent`.
4. `DoLogin` returns `BadCredentials` correctly when credentials are bad and captcha is also needed.
5. A deviceID is generated if it is already not set. Read my comment [here](https://github.com/geel9/SteamAuth/pull/8#issuecomment-164227799) for more info.
6. Allowed the user to select the SteamGuard scheme on deactivation. (2-Remove completely, 1-Switch to email)