### PR TITLE
Fixed device ID format not matching that of Steam's

### DIFF
--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -253,7 +253,7 @@ namespace SteamAuth
                 byte[] hashedBytes = sha1.ComputeHash(randomBytes);
                 string random32 = BitConverter.ToString(hashedBytes).Replace("-", "").Substring(0, 32).ToLower();
 
-                return SplitOnRatios(random32, new[] { 8, 4, 4, 4, 12 }, "-");
+                return "android:" + SplitOnRatios(random32, new[] { 8, 4, 4, 4, 12 }, "-");
             }
         }
 

--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -251,8 +251,27 @@ namespace SteamAuth
                 secureRandom.GetBytes(randomBytes);
 
                 byte[] hashedBytes = sha1.ComputeHash(randomBytes);
-                return "android:" + BitConverter.ToString(hashedBytes).Replace("-", "");
+                string random32 = BitConverter.ToString(hashedBytes).Replace("-", "").Substring(0, 32).ToLower();
+
+                return SplitOnRatios(random32, new[] { 8, 4, 4, 4, 12 }, "-");
             }
+        }
+
+        private static string SplitOnRatios(string str, int[] ratios, string intermediate)
+        {
+            string result = "";
+
+            int pos = 0;
+            for (int index = 0; index < ratios.Length; index++)
+            {
+                result += str.Substring(pos, ratios[index]);
+                pos = ratios[index];
+
+                if (index < ratios.Length - 1)
+                    result += intermediate;
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
I notice that the device IDs generated by SteamAuth are basically 40 random characters, which does not seem to be the format that Steam uses. Steam uses 32 chars separated by a '-' after 8,4,4,4 and 12 characters. Also, Steam's device IDs are in lowercase.

SteamAuth device ID example : 8248AC9BDA58618725404B88B121B5070F2A9C25
Steam device ID example : 71f62b82-05a4-2b82-2b82-2b8205a4e333

This should all be fixed in these commits. Feel free to test it again.

This pull request fixes #20.