### PR TITLE
Invalid Char "\" fix

### DIFF
--- a/SteamAuth/SteamGuardAccount.cs
+++ b/SteamAuth/SteamGuardAccount.cs
@@ -89,7 +89,8 @@ namespace SteamAuth
                 return "";
             }
 
-            byte[] sharedSecretArray = Convert.FromBase64String(this.SharedSecret);
+            string sharedSecretUnescaped = Regex.Unescape(this.SharedSecret);
+            byte[] sharedSecretArray = Convert.FromBase64String(sharedSecretUnescaped);
             byte[] timeArray = new byte[8];
 
             time /= 30L;


### PR DESCRIPTION
Fixes the issue with some shared secrets that have invalid base 64 chars like backslash "\" By using Regex.Unescape to unescape the escape sequence