### PR TITLE
FetchConfirmationAsync fix and HtmlDecode.

### DIFF
--- a/SteamAuth/SteamAuth.csproj
+++ b/SteamAuth/SteamAuth.csproj
@@ -36,6 +36,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/SteamAuth/SteamWeb.cs
+++ b/SteamAuth/SteamWeb.cs
@@ -116,7 +116,7 @@ namespace SteamAuth
                 request.ContentLength = query.Length;
 
                 StreamWriter requestStream = new StreamWriter(request.GetRequestStream());
-                requestStream.Write(query);
+                await requestStream.WriteAsync(query);
                 requestStream.Close();
             }
 
@@ -132,7 +132,7 @@ namespace SteamAuth
 
                 using (StreamReader responseStream = new StreamReader(response.GetResponseStream()))
                 {
-                    string responseData = responseStream.ReadToEnd();
+                    string responseData = await responseStream.ReadToEndAsync();
                     return responseData;
                 }
             }


### PR DESCRIPTION
Changes are
1. Remove duplicate code by adding FetchConfirmationInternal()
2. Fixed the old SteamWeb.FetchAsync() implementation. It actually wasn't asynchronous because ReadToEnd() and Write() blocks the thread.
3. Added a HtmlDecode when reading Confirmation descriptions. I suggested this a long time ago but obviously no one was paying attention.
