### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, this library can:
 * Remove itself from an account
 * Fetch, accept, and deny mobile confirmations
 
-#Requirements
+# Requirements
 
 * [Newtonsoft.Json](http://www.newtonsoft.com/json)
 
@@ -21,7 +21,7 @@ To add a mobile authenticator to a user, instantiate a `UserLogin` instance whic
 
 To fetch mobile confirmations, call `SteamGuardAccount.FetchConfirmations()`. You can then call `SteamGuardAccount.AcceptConfirmation` and `SteamGuardAccount.DenyConfirmation`.
 
-#Upcoming Features
+# Upcoming Features
 In order to be feature complete, this library will:
 
 * Be better documented (feature!!)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
