### PR TITLE
add support for email confirmation

### DIFF
--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -34,7 +34,7 @@ namespace SteamAuth
 
         private SessionData _session;
         private CookieContainer _cookies;
-		private bool confirmationEmailSent = false;
+        private bool confirmationEmailSent = false;
 
         public AuthenticatorLinker(SessionData session)
         {
@@ -53,17 +53,17 @@ namespace SteamAuth
             if (!hasPhone && PhoneNumber == null)
                 return LinkResult.MustProvidePhoneNumber;
 
-			if (!hasPhone) {
-				if (confirmationEmailSent) {
-					if (!_checkEmailConfirmation()) {
+            if (!hasPhone) {
+                if (confirmationEmailSent) {
+                    if (!_checkEmailConfirmation()) {
                     return LinkResult.GeneralFailure;
                 }
-				} else if (!_addPhoneNumber()) {
-					return LinkResult.GeneralFailure;
-				} else {
-					confirmationEmailSent = true;
-					return LinkResult.MustConfirmEmail;
-				}
+                } else if (!_addPhoneNumber()) {
+                    return LinkResult.GeneralFailure;
+                } else {
+                    confirmationEmailSent = true;
+                    return LinkResult.MustConfirmEmail;
+                }
             }
 
             var postData = new NameValueCollection();


### PR DESCRIPTION
Recently steam changed procedure of adding authenticator - now before adding phone number it's required to confirm email once more. This PR adds support for this step.