### PR TITLE
Implement moving of steam authenticator from another device

### DIFF
--- a/SteamAuth/SessionData.cs
+++ b/SteamAuth/SessionData.cs
@@ -22,10 +22,12 @@ namespace SteamAuth
             cookies.Add(new Cookie("mobileClient", "android", "/", ".steamcommunity.com"));
 
             cookies.Add(new Cookie("steamid", SteamID.ToString(), "/", ".steamcommunity.com"));
-            cookies.Add(new Cookie("steamLogin", SteamLogin, "/", ".steamcommunity.com")
-            {
-                HttpOnly = true
-            });
+
+            if (SteamLogin != null) {
+                cookies.Add(new Cookie("steamLogin", SteamLogin, "/", ".steamcommunity.com") {
+                    HttpOnly = true
+                });
+            }
 
             cookies.Add(new Cookie("steamLoginSecure", SteamLoginSecure, "/", ".steamcommunity.com")
             {

--- a/SteamAuth/SteamGuardAccount.cs
+++ b/SteamAuth/SteamGuardAccount.cs
@@ -40,7 +40,7 @@ namespace SteamAuth
         public string Secret1 { get; set; }
 
         [JsonProperty("status")]
-        public int Status { get; set; }
+        public int? Status { get; set; }
 
         [JsonProperty("device_id")]
         public string DeviceID { get; set; }

--- a/SteamAuth/UserLogin.cs
+++ b/SteamAuth/UserLogin.cs
@@ -134,7 +134,14 @@ namespace SteamAuth
 
             if (loginResponse.TwoFactorNeeded && !loginResponse.Success)
             {
+                var readableCookies = cookies.GetCookies(new Uri("https://steamcommunity.com"));
+
                 this.Requires2FA = true;
+                SessionData session = new SessionData();
+                session.SteamID = ulong.Parse(readableCookies["SteamLoginSecure"].Value.Split('%')[0]);
+                session.SteamLoginSecure = readableCookies["SteamLoginSecure"].Value;
+                session.SessionID = readableCookies["sessionid"].Value;
+                this.Session = session;
                 return LoginResult.Need2FA;
             }
 


### PR DESCRIPTION
Steam mobile app allows user to move authenticator to another device, as long as they still have valid phone number. From what I've heard (haven't tested myself), trade hold period is much lower this way comparing to removing authenticator and making new one, and also it's just convenient. So I decided SteamAuth (and SDA) need this feature. PR to SDA will follow.