### PR TITLE
fix link +86 phone number, not receive SMS code

### DIFF
--- a/SteamAuth/AuthenticatorLinker.cs
+++ b/SteamAuth/AuthenticatorLinker.cs
@@ -238,7 +238,17 @@ namespace SteamAuth
 
         private async Task<bool> _sendPhoneVerificationCode()
         {
-            await SteamWeb.POSTRequest("https://api.steampowered.com/IPhoneService/SendPhoneVerificationCode/v1?access_token=" + this.Session.AccessToken, null, null);
+            NameValueCollection Language = new NameValueCollection();
+            Language.Add("language", "6");
+
+            if (PhoneCountryCode == "86")
+            {
+                await SteamWeb.POSTRequest("https://api.steampowered.com/IPhoneService/SendPhoneVerificationCode/v1?access_token=" + this.Session.AccessToken, null, Language);
+            }
+            else
+            {
+                await SteamWeb.POSTRequest("https://api.steampowered.com/IPhoneService/SendPhoneVerificationCode/v1?access_token=" + this.Session.AccessToken, null, null);
+            }
             return true;
         }
 


### PR DESCRIPTION
If the mobile phone number linked on sda starts with +86, you cannot receive the sms code sent by steam, so add language = 6 so that can receive the sms code
see https://steamapi.xpaw.me/#IPhoneService/SendPhoneVerificationCode